### PR TITLE
Fix import path for bitcask

### DIFF
--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 )
 
 // CountRS - count replicas for service


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇